### PR TITLE
Redmine trunkでルーティングエラーとなります

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,3 @@
+ActionController::Routing::Routes.draw do |map|
+  map.connect 'banner/preview', :controller => 'banner', :action => 'preview'
+end


### PR DESCRIPTION
Redmine trunkでは、明示的にルーティングを記述しないと、ルーティングエラーとなるようですので、
routes.rb を追加させていただきました。

このような機能があると管理者の負担が減って便利ですね。
使ってみようと思います。
バナーの掲載期限みたいなものがあると、もっと便利かもしれませんね。
