### PR TITLE
Made tests run again... workaround

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,3 +10,7 @@ end
 SimpleCov.start
 
 require File.expand_path(File.dirname(__FILE__) + '/../../../test/test_helper')
+
+# TODO: Workaround: Fixtures_path could not be set temporary, so this has to do it
+ActiveRecord::Fixtures.create_fixtures(File.dirname(__FILE__) + '/fixtures/', 
+  File.basename("banners", '.*'))


### PR DESCRIPTION
Searched for a redmine plugin with actual tests. Used this to determine
how to include fixtures again due to Engines::-Error. Worked so far.
