### PR TITLE
Fix deprecation warning using Redmine 3.0

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do 
-  match 'projects/:project_id/banner/:action', :to => 'banner', :via => [:get, :post, :patch, :put]
+  match 'projects/:project_id/banner/:action', :controller => 'banner', :via => [:get, :post, :patch, :put]
   match 'projects/:project_id/banner/project_banner_off', :to => 'banner#project_banner_off', :via => [:get, :post]
   match 'banner/preview', :to => 'banner#preview',:via => [:get, :post]
   match 'banner/off', :to => 'banner#off', :via => [:get, :post]

--- a/test/integration/layout_test.rb
+++ b/test/integration/layout_test.rb
@@ -117,6 +117,6 @@ class LayoutTest < Redmine::IntegrationTest
     # Should include more link.
     get "/"
     assert_select 'div#banner_more_info'
-    assert_select 'div#banner_more_info a[href=http://www.redmine.org/]'
+    assert_select 'div#banner_more_info a[href="http://www.redmine.org/"]'
   end
 end


### PR DESCRIPTION
Fixes a deprecation warning in routes.rb and another one complaining about an invalid CSS selector.