### PR TITLE
Fix project-based Banner tab hiding due to other plugins.

### DIFF
--- a/lib/banner_projects_helper_patch.rb
+++ b/lib/banner_projects_helper_patch.rb
@@ -14,11 +14,10 @@ end
 module ProjectsHelperMethodsBanner
   def project_settings_tabs_with_banner
     tabs = project_settings_tabs_without_banner
-    action = {:name => 'banner', 
+    tabs.push({:name => 'banner',
       :controller => 'banner',
-      :action => :show, 
-      :partial => 'banner/show', :label => :banner}
-    tabs << action if User.current.allowed_to?(action, @project)
-    tabs
+      :action => :manage_banner,
+      :partial => 'banner/show', :label => :banner})
+    tabs.select {|tab| User.current.allowed_to?(tab[:action], @project)}
   end
 end


### PR DESCRIPTION
This fixes the issue of other plugins hiding the per-project Banner plugin due to the wrong :action being specified. 