### PR TITLE
Removed deprecation warning.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do 
-  match 'projects/:project_id/banner/:action', :to => 'banner', :via => [:get, :post, :patch, :put]
+  match 'projects/:project_id/banner/:action', :controller => 'banner', :via => [:get, :post, :patch, :put]
   match 'projects/:project_id/banner/project_banner_off', :to => 'banner#project_banner_off', :via => [:get, :post]
   match 'banner/preview', :to => 'banner#preview',:via => [:get, :post]
   match 'banner/off', :to => 'banner#off', :via => [:get, :post]


### PR DESCRIPTION
DEPRECATION WARNING: Defining a route where `to` is a controller without an action is deprecated. Please change `to: 'banner'` to `controller: 'banner'`. (called from block (3 levels) in <top (required)> at (eval):2)